### PR TITLE
서브헤더 컴포넌트 제작

### DIFF
--- a/components/commons/SubHeader/SubHeader.jsx
+++ b/components/commons/SubHeader/SubHeader.jsx
@@ -1,14 +1,32 @@
+import { Text, TouchableOpacity } from 'react-native';
 import Font from '../Font';
 import { AddTagBox, Box } from './SubHeader.style';
+import Tag from '@components/commons/Tag/Tag';
+import LinearGradient from 'react-native-linear-gradient';
 
-const SubHeader = () => {
-  return (
+const SubHeader = ({ onPress }) => {
+  return false ? (
+    <TouchableOpacity onPress={onPress}>
+      <Box>
+        <AddTagBox>
+          <Font size={14} weight={400}>
+            + 맞춤태그
+          </Font>
+        </AddTagBox>
+      </Box>
+    </TouchableOpacity>
+  ) : (
     <Box>
-      <AddTagBox>
-        <Font size={14} weight={400}>
-          + 맞춤태그
-        </Font>
-      </AddTagBox>
+      <Tag theme="angled" style={{ marginRight: 10 }} bgColor="#EBF5ED">
+        + 맞춤태그
+      </Tag>
+
+      <Tag theme="angled" style={{ marginRight: 10 }} bgColor="#C9EFD2">
+        안심등이 있어요
+      </Tag>
+      <Tag theme="angled" linearGradient={['#C9EFD2', '#FCDCBE']} style={{ marginRight: 10 }}>
+        +9
+      </Tag>
     </Box>
   );
 };

--- a/components/commons/SubHeader/SubHeader.jsx
+++ b/components/commons/SubHeader/SubHeader.jsx
@@ -1,0 +1,16 @@
+import Font from '../Font';
+import { AddTagBox, Box } from './SubHeader.style';
+
+const SubHeader = () => {
+  return (
+    <Box>
+      <AddTagBox>
+        <Font size={14} weight={400}>
+          + 맞춤태그
+        </Font>
+      </AddTagBox>
+    </Box>
+  );
+};
+
+export default SubHeader;

--- a/components/commons/SubHeader/SubHeader.style.js
+++ b/components/commons/SubHeader/SubHeader.style.js
@@ -7,6 +7,7 @@ export const Box = styled.View`
   background-color: #ffffff;
   position: relative;
   top: 0;
+  flex-direction: row;
 `;
 
 export const AddTagBox = styled.View`

--- a/components/commons/SubHeader/SubHeader.style.js
+++ b/components/commons/SubHeader/SubHeader.style.js
@@ -1,0 +1,19 @@
+import styled from 'styled-components/native';
+
+export const Box = styled.View`
+  width: 100%;
+  height: 54px;
+  padding: 12px 16px;
+  background-color: #ffffff;
+  position: relative;
+  top: 0;
+`;
+
+export const AddTagBox = styled.View`
+  width: 100%;
+  height: 30px;
+  background-color: #ebf5ed;
+  justify-content: center;
+  align-items: center;
+  border-radius: 10px;
+`;

--- a/components/commons/SubHeader/index.js
+++ b/components/commons/SubHeader/index.js
@@ -1,0 +1,2 @@
+import SubHeader from './SubHeader';
+export default SubHeader;

--- a/components/commons/Tag/Tag.jsx
+++ b/components/commons/Tag/Tag.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Pressable, StyleSheet } from 'react-native';
 import Font from '../Font';
 import { globals } from '@styles/globals.js';
+import LinearGradient from 'react-native-linear-gradient';
 
 // theme: 'angled' || 'rounded' (default: 'rounded')
 // bgColor, textColor (default: globals.colors.GREY_DARKER), borderColor: string
@@ -9,12 +10,14 @@ import { globals } from '@styles/globals.js';
 // borderWidth: null || number (default: 0.5)
 // style: StyleSheet
 // opPress: () => {}
+// linearGradient: ["시작 컬러", "끝 컬러"] (default: false)
 
 const Tag = ({
   theme = 'rounded',
   textColor = globals.colors.GREY_DARKER,
   onPress,
   icon,
+  linearGradient,
   ...props
 }) => {
   const styles = StyleSheet.create({
@@ -31,7 +34,16 @@ const Tag = ({
     },
   });
 
-  return (
+  return linearGradient ? (
+    <LinearGradient style={{ ...styles.button, ...props.style }} colors={[...linearGradient]}>
+      <Pressable style={{ backgroundColor: 'transparent' }} onPress={onPress}>
+        {icon && icon}
+        <Font color={textColor} size={props.textSize} weight={props.textWeight}>
+          {props.children}
+        </Font>
+      </Pressable>
+    </LinearGradient>
+  ) : (
     <Pressable style={[styles.button, props.style]} onPress={onPress}>
       {icon && icon}
       <Font color={textColor} size={props.textSize} weight={props.textWeight}>

--- a/screens/Recording/Search/Search.jsx
+++ b/screens/Recording/Search/Search.jsx
@@ -5,6 +5,7 @@ import { globals } from '@styles/globals';
 import { Font, BottomModal } from '@components/commons';
 import SearchBar from '@components/SearchBar/SearchBar';
 import TagsInModal from '@containers/Recording/TagsInModal';
+import SubHeader from '../../../components/commons/SubHeader';
 
 const Search = ({ navigation, route }) => {
   const [searchBarInput, setSearchBarInput] = useState('');
@@ -21,6 +22,7 @@ const Search = ({ navigation, route }) => {
   return (
     <SafeAreaView style={styles.container}>
       <SearchBar onSearch={setSearchBarInput} />
+      <SubHeader />
       <View style={styles.map_view}>
         <Pressable style={styles.marker_example} onPress={tagsModalOpen}>
           <Font textColor={globals.colors.BLACK}>MARKER</Font>

--- a/screens/Recording/Search/Search.jsx
+++ b/screens/Recording/Search/Search.jsx
@@ -22,7 +22,7 @@ const Search = ({ navigation, route }) => {
   return (
     <SafeAreaView style={styles.container}>
       <SearchBar onSearch={setSearchBarInput} />
-      <SubHeader />
+      <SubHeader onPress={tagsModalOpen} />
       <View style={styles.map_view}>
         <Pressable style={styles.marker_example} onPress={tagsModalOpen}>
           <Font textColor={globals.colors.BLACK}>MARKER</Font>


### PR DESCRIPTION
## 🔥 작업 동기 및 내용

- 서브헤더 컴포넌트 제작하였습니다.
- Recording/Search.jsx - 홈 화면에서 우측상단 검색 버튼 클릭 후 이동하는 페이지 쪽에 서브헤더 컴포넌트 테스트용으로 적용해두었습니다.
- 임시적으로 맞춤태그 `width:100%` 태그 하나만 있는 것과 태그 3개 이상일 경우 `+9` 태그까지 붙이는 컴포넌트 제작 해두었습니다. 기능 동작은 구현하지 않은 상태입니다.
- 안심태그 및 추천태그 둘 다 선택되었을 경우에 대해서만 `linearGradent` 속성을 적용해야 하는데, 컴포넌트 로직은 우선 구현 보류해두었습니다.
- Tag 컴포넌트 사용 시 `linearGradient={ ["시작 컬러", "끝 컬러" ] }`를 지정하면 자동으로 LinearGradient 컴포넌트로 감싸도록 Tag 컴포넌트 수정하였습니다!